### PR TITLE
ASC-537 Install openstack-ops test pccommon.sh

### DIFF
--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -1,5 +1,16 @@
 ---
-- name: Converge
-  hosts: all
-  roles:
-    - role: molecule-openstack-ops
+- hosts: infra1
+  tasks:
+  - name: Clone openstack-ansible-ops repo
+    git:
+     repo: https://github.com/rsoprivatecloud/openstack-ops
+     dest: /opt/openstack-ops
+     version: master
+  - name: Deploy openstack-ops
+    # takes about 15 minutes to complete
+    shell:
+     cmd: "source /usr/local/bin/openstack-ansible.rc ; openstack-ansible main.yml"
+     chdir: /opt/openstack-ops/playbooks
+     creates: /etc/sos.conf
+    args:
+     executable: /bin/bash

--- a/molecule/default/tests/test_pccommon.py
+++ b/molecule/default/tests/test_pccommon.py
@@ -1,0 +1,22 @@
+import os
+import pytest
+import testinfra.utils.ansible_runner
+
+
+"""ASC-536: Perform Service Delivery Sign Off Tasks"""
+
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('os-infra_hosts')[:1]
+
+
+@pytest.mark.test_id('ca13af99-5f93-11e8-8d43-6c96cfdb252f')
+def test_pccommon(host):
+    """Verify pccommon.sh runs without error"""
+    pre = ("lxc-attach -n $(lxc-ls -1 | grep utility | head -n 1) "
+           "-- bash -c '. /root/openrc ; ")
+    post = "'"
+    cmd = "{} source pccommon.sh {}".format(pre, post)
+    result = host.run(cmd)
+
+    assert result.rc == 0


### PR DESCRIPTION
Use playbook to install [openstack-ops](https://github.com/rsoprivatecloud/openstack-ops)
on `infra1`.

Add test to run
[pccommon.sh](https://github.com/rsoprivatecloud/openstack-ops/blob/master/playbooks/files/rpc-o-support/pccommon.sh)
and verify the exit code returned is '0'.