### PR TITLE
ASC-635 Delete created flavors

### DIFF
--- a/molecule/default/tests/test_pccommon.py
+++ b/molecule/default/tests/test_pccommon.py
@@ -21,3 +21,12 @@ def test_pccommon(host):
     result = host.run(cmd)
 
     assert result.rc == 0
+
+    # Tear down - delete all created flavors
+    utility_container = ("lxc-attach -n $(lxc-ls -1 | grep utility | head -n 1) "
+                         "-- bash -c '. /root/openrc ; ")
+
+    flavors = ['m1.tiny', 'm1.small', 'm1.medium', 'm1.large', 'm1.xlarge']
+    for flavor in flavors:
+        cmd = "{} openstack flavor delete {}'".format(utility_container, flavor)
+        host.run(cmd)


### PR DESCRIPTION
This commit adds a teardown step to the pccommon test to delete the
flavors created by the `openstack-ops` deployment. These flavors
conflict with the flavor creation in the `openstack-ansible-ops`
deployment used by other molecule repos.

TODO: It would be preferable to place this code in a pytest
`teardown_module()` method. It is unclear to me how to instanciate a
testinfra host object within such a method to accomplish this.